### PR TITLE
Map start and end date time of calendar view to query parameter

### DIFF
--- a/msgraph/generated/users/item/calendar_view/calendar_view_request_builder.py
+++ b/msgraph/generated/users/item/calendar_view/calendar_view_request_builder.py
@@ -137,6 +137,10 @@ class CalendarViewRequestBuilder():
                 return "%24skip"
             if original_name == "top":
                 return "%24top"
+            if original_name == "start_date_time":
+                return "startDateTime"
+            if original_name == "end_date_time":
+                return "endDateTime"
             return original_name
         
     


### PR DESCRIPTION
CalendarViewRequestBuilder does not map required start_date_time and end_date_time query parameters to query of CalendarView Request. This PR fixes the mapping.