### PR TITLE
Update client credential snippet to use default scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ credential = ClientSecretCredential(
     'client_id',
     'client_secret'
 )
-scopes = ['User.Read']
+scopes = ['https://graph.microsoft.com/.default']
 auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 request_adapter = GraphRequestAdapter(auth_provider)
 client = GraphServiceClient(request_adapter)


### PR DESCRIPTION
Fixes auth snippet that suggests you can use custom scopes with app access.

fixes #181 