### PR TITLE
Correcting a bug on the online_meeting_provider_type.py when retrieving Calendar of a user

### DIFF
--- a/msgraph/generated/models/online_meeting_provider_type.py
+++ b/msgraph/generated/models/online_meeting_provider_type.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 class OnlineMeetingProviderType(Enum):
     Unknown = "unknown",
-    SkypeForBusiness = "skypeForBusiness",
-    SkypeForConsumer = "skypeForConsumer",
-    TeamsForBusiness = "teamsForBusiness",
+    skypeForBusiness = "skypeForBusiness",
+    skypeForConsumer = "skypeForConsumer",
+    teamsForBusiness = "teamsForBusiness",
 


### PR DESCRIPTION
Hi!
I just found a bug inside the sdk for msgraph when you retrieving Calendar for a user. Here's the error raises when I try to retrieve the calendar. 
`Exception: Invalid key: ['teamsForBusiness'] for enum <enum 'OnlineMeetingProviderType'>.`
I find out that the ProdiverType was not correct so I corrected it!

Feel free if you want more data or information!
Kind regards,
WOOGMA team