### PR TITLE
Feature/simplify client creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0a13] - 2023-05-25
+
+### Added
+
+### Changed
+
+- Simplified the creation of a graph client. [#180](https://github.com/microsoftgraph/msgraph-sdk-python/issues/180)
+
 ## [1.0.0a12] - 2023-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ credential = ClientSecretCredential(
     client_secret='CLIENT_SECRET',
 )
 scopes = ['https://graph.microsoft.com/.default']
-client = GraphServiceClient(credentials=credentials, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 ```
 
 The above example uses default scopes for [app-only access](https://learn.microsoft.com/en-us/graph/permissions-overview?tabs=http#application-permissions).  If using [delegated access](https://learn.microsoft.com/en-us/graph/permissions-overview#delegated-permissions) you can provide custom scopes:
@@ -51,7 +51,7 @@ credential=DeviceCodeCredential(
     tenant_id='TENANT_ID',
 )
 scopes = ['User.Read', 'Mail.Read']
-client = GraphServiceClient(credentials=credentials, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 ```
 
 ## 3. Make requests against the service
@@ -73,7 +73,7 @@ credential = ClientSecretCredential(
     'client_secret'
 )
 scopes = ['https://graph.microsoft.com/.default']
-client = GraphServiceClient(credentials=credentials, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 
 async def get_user():
     user = await client.users.by_user_id('userPrincipalName').get()
@@ -92,7 +92,7 @@ from msgraph import GraphServiceClient
 
 credential = InteractiveBrowserCredential()
 scopes=['User.Read']
-client = GraphServiceClient(credentials=credentials, scopes=scopes,)
+client = GraphServiceClient(credentials=credential, scopes=scopes,)
 
 async def me():
     me = await client.me.get()

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ credential = ClientSecretCredential(
     client_secret='CLIENT_SECRET',
 )
 scopes = ['https://graph.microsoft.com/.default']
-client = GraphServiceClient(credentials, scopes=scopes)
+client = GraphServiceClient(credentials=credentials, scopes=scopes)
 ```
 
 The above example uses default scopes for [app-only access](https://learn.microsoft.com/en-us/graph/permissions-overview?tabs=http#application-permissions).  If using [delegated access](https://learn.microsoft.com/en-us/graph/permissions-overview#delegated-permissions) you can provide custom scopes:
@@ -51,7 +51,7 @@ credential=DeviceCodeCredential(
     tenant_id='TENANT_ID',
 )
 scopes = ['User.Read', 'Mail.Read']
-client = GraphServiceClient(credentials, scopes=scopes)
+client = GraphServiceClient(credentials=credentials, scopes=scopes)
 ```
 
 ## 3. Make requests against the service
@@ -73,7 +73,7 @@ credential = ClientSecretCredential(
     'client_secret'
 )
 scopes = ['https://graph.microsoft.com/.default']
-client = GraphServiceClient(credentials, scopes=scopes)
+client = GraphServiceClient(credentials=credentials, scopes=scopes)
 
 async def get_user():
     user = await client.users.by_user_id('userPrincipalName').get()
@@ -92,7 +92,7 @@ from msgraph import GraphServiceClient
 
 credential = InteractiveBrowserCredential()
 scopes=['User.Read']
-client = GraphServiceClient(credentials, scopes=scopes,)
+client = GraphServiceClient(credentials=credentials, scopes=scopes,)
 
 async def me():
     me = await client.me.get()

--- a/msgraph/_version.py
+++ b/msgraph/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '1.0.0a12'
+VERSION: str = '1.0.0a13'

--- a/msgraph/graph_service_client.py
+++ b/msgraph/graph_service_client.py
@@ -10,10 +10,10 @@ from .graph_request_adapter import GraphRequestAdapter
 class GraphServiceClient(BaseGraphServiceClient):
     def __init__(
         self,
-        credentials: Union[TokenCredential, AsyncTokenCredential],
-        scopes: Optional[List[str]],
-        base_url: Optional[str] = None,
-        client: Optional[AsyncClient] = None
+        credentials: Optional[Union[TokenCredential, AsyncTokenCredential]] = None,
+        scopes: Optional[List[str]] = None,
+        request_adapter: Optional[GraphRequestAdapter] = None
+        
     ) -> None:
         """Constructs a client instance to use for making requests to the 
         Microsoft Graph v.1.0 API.
@@ -23,24 +23,19 @@ class GraphServiceClient(BaseGraphServiceClient):
             tokenCredential to use for authentication. 
             scopes (Optional[List[str]]): The scopes to use for authentication.
             Defaults to ['https://graph.microsoft.com/.default'].
-            base_url (Optional[str], optional): The base url to use for
-            requests. Defaults to https://graph.microsoft.com/v1.0.
-            client (Optional[AsyncClient], optional): A custom httpx.AsyncClient
-            to use for http requests. Defaults to None.
+            request_adapter (Optional[GraphRequestAdapter], optional): The
+            request adapter to use for requests. Defaults to None.
         """
         
-        if scopes:
-            auth_provider = AzureIdentityAuthenticationProvider(credentials, scopes)
-        else:
-            auth_provider = AzureIdentityAuthenticationProvider(credentials)
-        
-        if client:
-            request_adapter = GraphRequestAdapter(auth_provider, client)
-        else:
+        if not request_adapter:
+            if not credentials:
+                raise ValueError("Missing request adapter or valid credentials")
+            
+            if scopes:
+                auth_provider = AzureIdentityAuthenticationProvider(credentials, scopes)
+            else:
+                auth_provider = AzureIdentityAuthenticationProvider(credentials)
+    
             request_adapter = GraphRequestAdapter(auth_provider)
-        
-        if base_url:
-            request_adapter.base_url = base_url
-        
         
         super().__init__(request_adapter)

--- a/msgraph/graph_service_client.py
+++ b/msgraph/graph_service_client.py
@@ -1,6 +1,46 @@
+from typing import List, Optional, TYPE_CHECKING, Union'
+from azure.core.credentials import TokenCredential
+from azure.core.credentials_async import AsyncTokenCredential
+from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
+from httpx import AsyncClient
+
 from .generated.base_graph_service_client import BaseGraphServiceClient
 from .graph_request_adapter import GraphRequestAdapter
 
 class GraphServiceClient(BaseGraphServiceClient):
-    def __init__(self, request_adapter: GraphRequestAdapter) -> None:
+    def __init__(
+        self,
+        credentials: Union[TokenCredential, AsyncTokenCredential],
+        scopes: Optional[List[str]],
+        base_url: Optional[str] = None,
+        client: Optional[AsyncClient] = None
+    ) -> None:
+        """Constructs a client instance to use for making requests to the 
+        Microsoft Graph v.1.0 API.
+
+        Args:
+            credentials (Union[TokenCredential, AsyncTokenCredential]): The
+            tokenCredential to use for authentication. 
+            scopes (Optional[List[str]]): The scopes to use for authentication.
+            Defaults to ['https://graph.microsoft.com/.default'].
+            base_url (Optional[str], optional): The base url to use for
+            requests. Defaults to https://graph.microsoft.com/v1.0.
+            client (Optional[AsyncClient], optional): A custom httpx.AsyncClient
+            to use for http requests. Defaults to None.
+        """
+        
+        if scopes:
+            auth_provider = AzureIdentityAuthenticationProvider(credentials, scopes)
+        else:
+            auth_provider = AzureIdentityAuthenticationProvider(credentials)
+        
+        if client:
+            request_adapter = GraphRequestAdapter(auth_provider, client)
+        else:
+            request_adapter = GraphRequestAdapter(auth_provider)
+        
+        if base_url:
+            request_adapter.base_url = base_url
+        
+        
         super().__init__(request_adapter)

--- a/msgraph/graph_service_client.py
+++ b/msgraph/graph_service_client.py
@@ -23,8 +23,8 @@ class GraphServiceClient(BaseGraphServiceClient):
             tokenCredential to use for authentication. 
             scopes (Optional[List[str]]): The scopes to use for authentication.
             Defaults to ['https://graph.microsoft.com/.default'].
-            request_adapter (Optional[GraphRequestAdapter], optional): The
-            request adapter to use for requests. Defaults to None.
+            request_adapter (Optional[GraphRequestAdapter], optional): The request
+            adapter to use for requests. Defaults to None.
         """
         
         if not request_adapter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "msgraph-sdk"
-version = "1.0.0a12"
+version = "1.0.0a13"
 authors = [{name = "Microsoft", email = "graphtooling+python@microsoft.com"}]
 description = "The Microsoft Graph Python SDK"
 dependencies = [
@@ -59,7 +59,7 @@ pythonpath = [
 ]
 
 [tool.bumpver]
-current_version = "1.0.0a12"
+current_version = "1.0.0a13"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/samples/applications_samples.md
+++ b/samples/applications_samples.md
@@ -11,11 +11,11 @@ from msgraph import GraphServiceClient
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 # Create a credential object. Used to authenticate requests
-credential=EnvironmentCredential()
+credentials = EnvironmentCredential()
 scopes = ['https://graph.microsoft.com/.default']
 
 # Create an API client with the credentials and scopes
-client = GraphServiceClient(credentials, scopes=scopes)
+client = GraphServiceClient(credentials=credentials, scopes=scopes)
 ```
 
 ## 1. LIST ALL APPLICATIONS IN THE TENANT (GET /applications)

--- a/samples/applications_samples.md
+++ b/samples/applications_samples.md
@@ -5,22 +5,17 @@ import asyncio
 
 from azure.identity import EnvironmentCredential
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter
 from msgraph import GraphServiceClient
 
 # Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-# Create authentication provider object. Used to authenticate request
+# Create a credential object. Used to authenticate requests
 credential=EnvironmentCredential()
-auth_provider = AzureIdentityAuthenticationProvider(credential)
+scopes = ['https://graph.microsoft.com/.default']
 
-# Initialize a request adapter. Handles the HTTP concerns.
-request_adapter = GraphRequestAdapter(auth_provider)
-
-# Get a service client.
-client = GraphServiceClient(request_adapter)
+# Create an API client with the credentials and scopes
+client = GraphServiceClient(credentials, scopes=scopes)
 ```
 
 ## 1. LIST ALL APPLICATIONS IN THE TENANT (GET /applications)

--- a/samples/authentication_samples.md
+++ b/samples/authentication_samples.md
@@ -7,26 +7,21 @@ import asyncio
 
 from azure.identity import DeviceCodeCredential
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter, GraphServiceClient
+from msgraph import GraphServiceClient
 
 # Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-# Create authentication provider object. Used to authenticate requests
+# Create a credential object. Used to authenticate requests
 credential = DeviceCodeCredential(
     client_id='CLIENT_ID',
     tenant_id='TENANT_ID',
     )
 
 scopes = ["User.Read"]
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 
-# Initialize a request adapter with the auth provider.
-request_adapter = GraphRequestAdapter(auth_provider)
-
-# Create an API client with the request adapter.
-client = GraphServiceClient(request_adapter)
+# Create an API client with the credentials and scopes.
+client = GraphServiceClient(credential, scopes=scopes)
 
 # GET A USER USING THE USER ID (GET /users/{id})
 async def get_user():
@@ -46,22 +41,17 @@ asyncio.run(get_user())
 import asyncio
 from azure.identity import InteractiveBrowserCredential
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter, GraphServiceClient
+from msgraph import GraphServiceClient
 
 # Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-# Create authentication provider object. Used to authenticate requests
+# Create a credential object. Used to authenticate requests 
 credential = InteractiveBrowserCredential()
 scopes = ["User.Read"]
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 
-# Initialize a request adapter with the auth provider.
-request_adapter = GraphRequestAdapter(auth_provider)
-
-# Create an API client with the request adapter.
-client = GraphServiceClient(request_adapter)
+# Create an API client with the credentials and scopes.
+client = GraphServiceClient(credential, scopes=scopes)
 
 # GET A USER USING THE USER ID (GET /users/{id})
 async def get_user():
@@ -83,26 +73,21 @@ import asyncio
 
 from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter, GraphServiceClient
+from msgraph import GraphServiceClient
 
 # Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy()) 
 
-# Create authentication provider object. Used to authenticate request
+# Create a credential object. Used to authenticate requests
 credential = ClientSecretCredential(
     tenant_id='TENANT_ID',
     client_id='CLIENT_ID',
     client_secret='CLIENT_SECRET'
 )
 scopes = ['https://graph.microsoft.com/.default']
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 
-# Initialize a request adapter with the auth provider.
-request_adapter = GraphRequestAdapter(auth_provider)
-
-# Create an API client with the request adapter.
-client = GraphServiceClient(request_adapter)
+# Create an API client with the credentials and scopes.
+client = GraphServiceClient(credential, scopes=scopes)
 
 # GET A USER USING THE USER ID (GET /users/{id})
 async def get_user():
@@ -122,22 +107,17 @@ import asyncio
 
 from azure.identity.aio import EnvironmentCredential
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter, GraphServiceClient
+from msgraph import GraphServiceClient
 
 # Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-# Create authentication provider object. Used to authenticate request
+# Create a credential object. Used to authenticate requests
 credential = EnvironmentCredential()
 scopes = ['https://graph.microsoft.com/.default']
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 
-# Initialize a request adapter with the auth provider.
-request_adapter = GraphRequestAdapter(auth_provider)
-
-# Create an API client with the request adapter.
-client = GraphServiceClient(request_adapter)
+# Create an API client with the credentials and scopes.
+client = GraphServiceClient(credential, scopes=scopes)
 
 # GET A USER USING THE USER ID (GET /users/{id})
 async def get_user():

--- a/samples/authentication_samples.md
+++ b/samples/authentication_samples.md
@@ -21,7 +21,7 @@ credential = DeviceCodeCredential(
 scopes = ["User.Read"]
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient(credential, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 
 # GET A USER USING THE USER ID (GET /users/{id})
 async def get_user():
@@ -51,7 +51,7 @@ credential = InteractiveBrowserCredential()
 scopes = ["User.Read"]
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient(credential, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 
 # GET A USER USING THE USER ID (GET /users/{id})
 async def get_user():
@@ -87,7 +87,7 @@ credential = ClientSecretCredential(
 scopes = ['https://graph.microsoft.com/.default']
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient(credential, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 
 # GET A USER USING THE USER ID (GET /users/{id})
 async def get_user():
@@ -117,7 +117,7 @@ credential = EnvironmentCredential()
 scopes = ['https://graph.microsoft.com/.default']
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient(credential, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 
 # GET A USER USING THE USER ID (GET /users/{id})
 async def get_user():

--- a/samples/drives_samples.md
+++ b/samples/drives_samples.md
@@ -5,26 +5,21 @@ import asyncio
 
 from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter, GraphServiceClient
+from msgraph import GraphServiceClient
 
 # (Optional) Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy()) 
 
-# Create authentication provider object. Used to authenticate request
+# Create a credential object. Used to authenticate requests
 credential = ClientSecretCredential(
     tenant_id='TENANT_ID',
     client_id='CLIENT_ID',
     client_secret='CLIENT_SECRET'
 )
 scopes = ['https://graph.microsoft.com/.default']
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 
-# Initialize a request adapter with the auth provider.
-request_adapter = GraphRequestAdapter(auth_provider)
-
-# Create an API client with the request adapter.
-client = GraphServiceClient(request_adapter)
+# Create an API client with the credentials and scopes.
+client = GraphServiceClient()
 ```
 
 ## 1. LIST ALL DRIVES (GET /drives)

--- a/samples/drives_samples.md
+++ b/samples/drives_samples.md
@@ -19,8 +19,7 @@ credential = ClientSecretCredential(
 scopes = ['https://graph.microsoft.com/.default']
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient(credentials, scopes=scopes)
-```
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 ```
 
 ## 1. LIST ALL DRIVES (GET /drives)

--- a/samples/drives_samples.md
+++ b/samples/drives_samples.md
@@ -19,7 +19,8 @@ credential = ClientSecretCredential(
 scopes = ['https://graph.microsoft.com/.default']
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient()
+client = GraphServiceClient(credentials, scopes=scopes)
+```
 ```
 
 ## 1. LIST ALL DRIVES (GET /drives)

--- a/samples/general_samples.md
+++ b/samples/general_samples.md
@@ -18,7 +18,7 @@ credentials = AuthorizationCodeCredential(
     redirect_uri: str
 )
 scopes = ['User.Read', 'Mail.ReadWrite']
-client = GraphServiceClient(credentials, scopes=scopes)
+client = GraphServiceClient(credentials=credentials, scopes=scopes)
 ```
 
 ## 2. Creating a Graph client using a custom `httpx.AsyncClient` instance
@@ -28,7 +28,8 @@ from msgraph import GraphRequestAdapter
 from msgraph_core import GraphClientFactory
 
 http_client = GraphClientFactory.create_with_default_middleware(client=httpx.AsyncClient())
-client = GraphServiceClient(credentials, scopes=scopes, client=http_client)
+request_adapter = GraphRequestAdapter(auth_provider, http_client)
+client = GraphServiceClient(request_adapter=request_adapter)
 ```
 
 ## 3. Get an item from the Microsoft Graph API
@@ -159,7 +160,7 @@ credential = ClientSecretCredential(
     'client_secret'
 )
 scopes = ['Mail.Send']
-client = GraphServiceClient(credential, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 
 async def send_mail():
     try:

--- a/samples/general_samples.md
+++ b/samples/general_samples.md
@@ -6,23 +6,19 @@ This creates a default Graph client that uses `https://graph.microsoft.com` as t
 ```py
 from azure.identity import AuthorizationCodeCredential
 from kiota_abstactions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter
 from msgraph import GraphServiceClient
 
 # Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-AuthorizationCodeCredential(
+credentials = AuthorizationCodeCredential(
     tenant_id: str,
     client_id: str,
     authorization_code: str,
     redirect_uri: str
 )
 scopes = ['User.Read', 'Mail.ReadWrite']
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
-request_adapter = GraphRequestAdapter(auth_provider)
-client = GraphServiceClient(request_adapter)
+client = GraphServiceClient(credentials, scopes=scopes)
 ```
 
 ## 2. Creating a Graph client using a custom `httpx.AsyncClient` instance
@@ -32,7 +28,7 @@ from msgraph import GraphRequestAdapter
 from msgraph_core import GraphClientFactory
 
 http_client = GraphClientFactory.create_with_default_middleware(client=httpx.AsyncClient())
-request_adapter = GraphRequestAdapter(auth_provider, http_client)
+client = GraphServiceClient(credentials, scopes=scopes, client=http_client)
 ```
 
 ## 3. Get an item from the Microsoft Graph API
@@ -144,8 +140,6 @@ Ensure you have the [right permissions](https://docs.microsoft.com/en-us/graph/a
 
 ```py
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter
 from msgraph import GraphServiceClient
 
 from msgraph.generated.me.send_mail.send_mail_post_request_body import SendMailPostRequestBody
@@ -165,9 +159,7 @@ credential = ClientSecretCredential(
     'client_secret'
 )
 scopes = ['Mail.Send']
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
-request_adapter = GraphRequestAdapter(auth_provider)
-client = GraphServiceClient(request_adapter)
+client = GraphServiceClient(credential, scopes=scopes)
 
 async def send_mail():
     try:

--- a/samples/groups_samples.md
+++ b/samples/groups_samples.md
@@ -19,7 +19,7 @@ credential = ClientSecretCredential(
 scopes = ['https://graph.microsoft.com/.default']
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient(credential, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 ```
 
 ## 1. LIST ALL GROUPS IN THE TENANT (GET /groups)

--- a/samples/groups_samples.md
+++ b/samples/groups_samples.md
@@ -5,26 +5,21 @@ import asyncio
 
 from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter, GraphServiceClient
+from msgraph import GraphServiceClient
 
 # Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy()) 
 
-# Create authentication provider object. Used to authenticate request
+# Create a credential object. Used to authenticate requests
 credential = ClientSecretCredential(
     tenant_id='TENANT_ID',
     client_id='CLIENT_ID',
     client_secret='CLIENT_SECRET'
 )
 scopes = ['https://graph.microsoft.com/.default']
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 
-# Initialize a request adapter with the auth provider.
-request_adapter = GraphRequestAdapter(auth_provider)
-
-# Create an API client with the request adapter.
-client = GraphServiceClient(request_adapter)
+# Create an API client with the credentials and scopes.
+client = GraphServiceClient(credential, scopes=scopes)
 ```
 
 ## 1. LIST ALL GROUPS IN THE TENANT (GET /groups)

--- a/samples/users_samples.md
+++ b/samples/users_samples.md
@@ -19,7 +19,7 @@ credential = ClientSecretCredential(
 scopes = ['https://graph.microsoft.com/.default']
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient(credential, scopes=scopes)
+client = GraphServiceClient(credentials=credential, scopes=scopes)
 ```
 
 ## 1. GET ALL USERS IN A TENANT (GET /users)

--- a/samples/users_samples.md
+++ b/samples/users_samples.md
@@ -5,25 +5,20 @@ import asyncio
 
 from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph import GraphRequestAdapter, GraphServiceClient
+from msgraph import GraphServiceClient
 
 # Set the event loop policy for Windows
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy()) 
 
-# Create authentication provider object. Used to authenticate request
+# Create a credential object. Used to authenticate requests
 credential = ClientSecretCredential(
     tenant_id='TENANT_ID',
     client_id='CLIENT_ID',
     client_secret='CLIENT_SECRET'
 )
 scopes = ['https://graph.microsoft.com/.default']
-auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 
-# Initialize a request adapter with the auth provider.
-request_adapter = GraphRequestAdapter(auth_provider)
-
-# Create an API client with the request adapter.
+# Create an API client with the credentials and scopes.
 client = GraphServiceClient(request_adapter)
 ```
 

--- a/samples/users_samples.md
+++ b/samples/users_samples.md
@@ -19,7 +19,7 @@ credential = ClientSecretCredential(
 scopes = ['https://graph.microsoft.com/.default']
 
 # Create an API client with the credentials and scopes.
-client = GraphServiceClient(request_adapter)
+client = GraphServiceClient(credential, scopes=scopes)
 ```
 
 ## 1. GET ALL USERS IN A TENANT (GET /users)


### PR DESCRIPTION
Simplifies the initialization of a graph client from

```py
auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
# Initialize a request adapter. Handles the HTTP concerns
request_adapter = GraphRequestAdapter(auth_provider)
# Get a service client
client = GraphServiceClient(request_adapter)
```
to

```py
client = GraphServiceClient(credentials=credential, scopes=scopes)
```

closes #180 