### PR TITLE
Revert "Bump httpx[http2] from 0.25.1 to 0.25.2"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -88,7 +88,7 @@ hpack==4.0.0 ; python_full_version >= '3.6.1'
 
 httpcore==0.18.0 ; python_version >= '3.7'
 
-httpx[http2]==0.25.2 ; python_version >= '3.7'
+httpx[http2]==0.25.1 ; python_version >= '3.7'
 
 hyperframe==6.0.1 ; python_full_version >= '3.6.1'
 


### PR DESCRIPTION
Reverts microsoftgraph/msgraph-sdk-python#482

Because it should not have been merged since it fails #484 