### PR TITLE
Do not use mutable default arguments

### DIFF
--- a/msgraph/graph_request_adapter.py
+++ b/msgraph/graph_request_adapter.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 import httpx
 from kiota_abstractions.authentication import AuthenticationProvider
 from kiota_http.middleware.options import UrlReplaceHandlerOption
@@ -20,5 +20,7 @@ options = {
 
 class GraphRequestAdapter(BaseGraphRequestAdapter):
     def __init__(self, auth_provider: AuthenticationProvider,
-                 client: Optional[httpx.AsyncClient] = GraphClientFactory.create_with_default_middleware(options=options)) -> None:
+                 client: Optional[httpx.AsyncClient] = None) -> None:
+        if client is None:
+            client = GraphClientFactory.create_with_default_middleware(options=options)
         super().__init__(auth_provider, http_client=client)


### PR DESCRIPTION
Using mutable default arguments is a common Python problem, see e.g. https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

In this specific case the default argument even tries to setup some infrastructure settings at import time, which can potentially fail.

Note that this commit is changing the behavior for user passing in `None` to the changed method, as it will now create an `AsyncClient` with the options specified within the module. In the previous behavior it would have raised an exception deeper down the call stack (see http://github.com/microsoft/kiota-http-python/pull/383/files).