### PR TITLE
ci: fixes publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Install flit
-        run: |
-          pip install flit
       - name: Publish the distibution to PyPI
-        run: flit publish
-        env:
-          FLIT_INDEX_URL: https://upload.pypi.org/legacy/
-          FLIT_USERNAME: __token__
-          FLIT_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@v1.9.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
       - name: Publish the distibution to PyPI
         uses: pypa/gh-action-pypi-publish@v1.9.0
         with:


### PR DESCRIPTION
related #738, follows https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ instructions without signing or id-token due to security restrictions.
context https://github.com/microsoftgraph/msgraph-sdk-python/actions/runs/9860380451/job/27226438544