### PR TITLE
Bump kiota abstr to >=1.3.0 due to multipart support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "Microsoft", email = "graphtooling+python@microsoft.com"}]
 description = "The Microsoft Graph Python SDK"
 dependencies = [
     "azure-identity >=1.12.0",
-    "microsoft-kiota-abstractions >=1.0.0,<2.0.0",
+    "microsoft-kiota-abstractions >=1.3.0,<2.0.0",
     "microsoft-kiota-authentication-azure >=1.0.0,<2.0.0",
     "microsoft-kiota-serialization-json >=1.0.0,<2.0.0",
     "microsoft-kiota-serialization-text >=1.0.0,<2.0.0",


### PR DESCRIPTION
Due to the reliance on the multipart support added in v1.3.0 of https://github.com/microsoft/kiota-abstractions-python, as seen in https://github.com/microsoftgraph/msgraph-sdk-python/blob/2ef486c7bd9c418138d7bb64b5fe99926a470149/msgraph/generated/base_graph_service_client.py#L12, I would advocate for bumping the minimum version specified inside pyproject to reflect said dependency. Otherwise, upgrading the pip module will not bump kiota abstractions.