### PR TITLE
Expose type information

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+warn_unused_configs = true
+files = "msgraph"
+ignore_missing_imports = true
+
+[mypy-msgraph.generated.*]
+ignore_errors = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ warn_unused_configs = true
 files = "msgraph"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "msgraph.generated"
+ignore_errors = true
+
 [tool.yapf]
 based_on_style = "pep8"
 dedent_closing_brackets = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,6 @@ push = false
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"', 'version = "{version}"']
 "msgraph/_version.py" = ["{version}"]
+
+[tool.poetry.packages]
+include = ["msgraph"]


### PR DESCRIPTION
Closes  https://github.com/microsoftgraph/msgraph-sdk-python/issues/655


Before
When importing classes from this project, an error is shown:

```
auth_update.py:5: error: Skipping analyzing "msgraph": module is installed, but missing library stubs or py.typed marker [import-untyped]
```

After:
With This PR, there are no reported errors on type checking and typechecking allows shows no issues
```
Success: no issues found in 1 source file
```
