### PR TITLE
Remove unused poetry config causing dependabot failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,3 @@ push = false
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"', 'version = "{version}"']
 "msgraph/_version.py" = ["{version}"]
-
-[tool.poetry.packages]
-include = ["msgraph"]


### PR DESCRIPTION
similar to https://github.com/microsoftgraph/msgraph-sdk-python-core/pull/719

Dependabot [failures](https://github.com/microsoftgraph/msgraph-sdk-python/network/updates/924439545)