### PR TITLE
Added Support for: /security/attackSimulation/simulations/{simulationId}/report/simulationUsers Endpoint

### DIFF
--- a/msgraph/generated/models/user_simulation_details_collection_response.py
+++ b/msgraph/generated/models/user_simulation_details_collection_response.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from kiota_abstractions.serialization import Parsable, ParseNode, SerializationWriter
+from typing import Any, Optional, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from .base_collection_pagination_count_response import BaseCollectionPaginationCountResponse
+    from .user_simulation_details import UserSimulationDetails
+
+from .base_collection_pagination_count_response import BaseCollectionPaginationCountResponse
+
+@dataclass
+class UserSimulationDetailsCollectionResponse(BaseCollectionPaginationCountResponse, Parsable):
+    # The value property
+    value: Optional[list[UserSimulationDetails]] = None
+    
+    @staticmethod
+    def create_from_discriminator_value(parse_node: ParseNode) -> UserSimulationDetailsCollectionResponse:
+        """
+        Creates a new instance of the appropriate class based on discriminator value
+        param parse_node: The parse node to use to read the discriminator value and create the object
+        Returns: UserSimulationDetailsCollectionResponse
+        """
+        if parse_node is None:
+            raise TypeError("parse_node cannot be null.")
+        return UserSimulationDetailsCollectionResponse()
+    
+    def get_field_deserializers(self,) -> dict[str, Callable[[ParseNode], None]]:
+        """
+        The deserialization information for the current model
+        Returns: dict[str, Callable[[ParseNode], None]]
+        """
+
+        from .base_collection_pagination_count_response import BaseCollectionPaginationCountResponse
+        from .user_simulation_details import UserSimulationDetails
+
+        from .base_collection_pagination_count_response import BaseCollectionPaginationCountResponse
+        from .user_simulation_details import UserSimulationDetails
+
+        fields: dict[str, Callable[[Any], None]] = {
+            "value": lambda n : setattr(self, 'value', n.get_collection_of_object_values(UserSimulationDetails)),
+        }
+        super_fields = super().get_field_deserializers()
+        fields.update(super_fields)
+        return fields
+    
+    def serialize(self,writer: SerializationWriter) -> None:
+        """
+        Serializes information the current object
+        param writer: Serialization writer to use to serialize this model
+        Returns: None
+        """
+        if writer is None:
+            raise TypeError("writer cannot be null.")
+        super().serialize(writer)
+        writer.write_collection_of_object_values("value", self.value)

--- a/msgraph/generated/security/attack_simulation/simulations/item/report/simulation_users_report_request_builder.py
+++ b/msgraph/generated/security/attack_simulation/simulations/item/report/simulation_users_report_request_builder.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from kiota_abstractions.base_request_builder import BaseRequestBuilder
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from kiota_abstractions.default_query_parameters import QueryParameters
+from kiota_abstractions.get_path_parameters import get_path_parameters
+from kiota_abstractions.method import Method
+from kiota_abstractions.request_adapter import RequestAdapter
+from kiota_abstractions.request_information import RequestInformation
+from kiota_abstractions.request_option import RequestOption
+from kiota_abstractions.serialization import Parsable, ParsableFactory
+from typing import Any, Optional, TYPE_CHECKING, Union
+from warnings import warn
+
+if TYPE_CHECKING:
+    from ......models.user_simulation_details_collection_response import UserSimulationDetailsCollectionResponse
+    from ......models.o_data_errors.o_data_error import ODataError
+
+class SimulationUsersReportRequestBuilder(BaseRequestBuilder):
+    """
+    Provides operations to manage the report/simulationUsers property of the microsoft.graph.simulation entity.
+    """
+    def __init__(self,request_adapter: RequestAdapter, path_parameters: Union[str, dict[str, Any]]) -> None:
+        """
+        Instantiates a new SimulationUsersReportRequestBuilder and sets the default values.
+        param path_parameters: The raw url or the url-template parameters for the request.
+        param request_adapter: The request adapter to use to execute the requests.
+        Returns: None
+        """
+        super().__init__(request_adapter, "{+baseurl}/security/attackSimulation/simulations/{simulation%2Did}/report/simulationUsers{?%24top,%24skipToken,%24count}", path_parameters)
+    
+    async def get(self,request_configuration: Optional[RequestConfiguration[SimulationUsersReportRequestBuilderGetQueryParameters]] = None) -> Optional[UserSimulationDetailsCollectionResponse]:
+        """
+        A collection of users in the simulation
+        param request_configuration: Configuration for the request such as headers, query parameters, and middleware options.
+        Returns: Optional[LandingPage]
+        """
+        request_info = self.to_get_request_information(
+            request_configuration
+        )
+        from ......models.o_data_errors.o_data_error import ODataError
+
+        error_mapping: dict[str, type[ParsableFactory]] = {
+            "XXX": ODataError,
+        }
+        if not self.request_adapter:
+            raise Exception("Http core is null") 
+        from ......models.user_simulation_details_collection_response import UserSimulationDetailsCollectionResponse
+
+        return await self.request_adapter.send_async(request_info, UserSimulationDetailsCollectionResponse, error_mapping)
+    
+    def to_get_request_information(self,request_configuration: Optional[RequestConfiguration[SimulationUsersReportRequestBuilderGetQueryParameters]] = None) -> RequestInformation:
+        """
+        The landing page associated with a simulation during its creation.
+        param request_configuration: Configuration for the request such as headers, query parameters, and middleware options.
+        Returns: RequestInformation
+        """
+        request_info = RequestInformation(Method.GET, self.url_template, self.path_parameters)
+        request_info.configure(request_configuration)
+        request_info.headers.try_add("Accept", "application/json")
+        return request_info
+    
+    def with_url(self,raw_url: str) -> SimulationUsersReportRequestBuilder:
+        """
+        Returns a request builder with the provided arbitrary URL. Using this method means any other path or query parameters are ignored.
+        param raw_url: The raw URL to use for the request builder.
+        Returns: SimulationUsersReportRequestBuilder
+        """
+        if raw_url is None:
+            raise TypeError("raw_url cannot be null.")
+        return SimulationUsersReportRequestBuilder(self.request_adapter, raw_url)
+    
+    @dataclass
+    class SimulationUsersReportRequestBuilderGetQueryParameters():
+        """
+        The landing page associated with a simulation during its creation.
+        """
+        def get_query_parameter(self,original_name: str) -> str:
+            """
+            Maps the query parameters names to their encoded names for the URI template parsing.
+            param original_name: The original query parameter name in the class.
+            Returns: str
+            """
+            if original_name is None:
+                raise TypeError("original_name cannot be null.")
+            if original_name == "top":
+                return "%24top"
+            if original_name == "count":
+                return "%24count"
+            if original_name == "skipToken":
+                return "%24skipToken"
+            return original_name
+        
+        # Expand related entities
+        expand: Optional[list[str]] = None
+
+        # Select properties to be returned
+        select: Optional[list[str]] = None
+
+    
+    @dataclass
+    class SimulationUsersReportRequestBuilderGetRequestConfiguration(RequestConfiguration[SimulationUsersReportRequestBuilderGetQueryParameters]):
+        """
+        Configuration for the request such as headers, query parameters, and middleware options.
+        """
+        warn("This class is deprecated. Please use the generic RequestConfiguration class generated by the generator.", DeprecationWarning)
+    
+

--- a/msgraph/generated/security/attack_simulation/simulations/item/simulation_item_request_builder.py
+++ b/msgraph/generated/security/attack_simulation/simulations/item/simulation_item_request_builder.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from .landing_page.landing_page_request_builder import LandingPageRequestBuilder
     from .login_page.login_page_request_builder import LoginPageRequestBuilder
     from .payload.payload_request_builder import PayloadRequestBuilder
+    from .report.simulation_users_report_request_builder import SimulationUsersReportRequestBuilder
 
 class SimulationItemRequestBuilder(BaseRequestBuilder):
     """
@@ -170,7 +171,16 @@ class SimulationItemRequestBuilder(BaseRequestBuilder):
         from .payload.payload_request_builder import PayloadRequestBuilder
 
         return PayloadRequestBuilder(self.request_adapter, self.path_parameters)
-    
+
+    @property
+    def report_simulation_users(self) -> SimulationUsersReportRequestBuilder:
+        """
+        Provides operations to manage the payload property of the microsoft.graph.simulation entity.
+        """
+        from .report.simulation_users_report_request_builder import SimulationUsersReportRequestBuilder
+
+        return SimulationUsersReportRequestBuilder(self.request_adapter, self.path_parameters)
+
     @dataclass
     class SimulationItemRequestBuilderDeleteRequestConfiguration(RequestConfiguration[QueryParameters]):
         """


### PR DESCRIPTION
Added preliminary support for the:
/security/attackSimulation/simulations/{simulationId}/report/simulationUsers

Endpoint following the project style + Microsoft's documentation.

Not sure how open this repo is to contributions but here's a teeny tiny bit.

Please let me know if I've followed the project structure correctly - reverse engineering it has been a bit of a thing.