### PR TITLE
fix(docs): correct comment to reflect raw bytes instead of base64

### DIFF
--- a/msgraph/generated/models/file_attachment.py
+++ b/msgraph/generated/models/file_attachment.py
@@ -13,7 +13,7 @@ from .attachment import Attachment
 class FileAttachment(Attachment, Parsable):
     # The OdataType property
     odata_type: Optional[str] = "#microsoft.graph.fileAttachment"
-    # The base64-encoded contents of the file.
+    # The raw bytes of the file.
     content_bytes: Optional[bytes] = None
     # The ID of the attachment in the Exchange store.
     content_id: Optional[str] = None


### PR DESCRIPTION
This PR updates the field comment for `content_bytes` to correctly describe its purpose. The comment previously stated that the value was *Base64-encoded*, but the field type (`bytes`) indicates it contains raw binary data.

###  Changes

* Updated the comment to reflect that `content_bytes` holds **raw bytes**, not **Base64-encoded content**.

###  Reason for Change

The previous comment was misleading and inconsistent with the field’s type annotation. This correction improves clarity and helps prevent confusion for developers using or maintaining the code.

When base64 used instead, I was getting this error below:
```
APIError
Code: 400
ErrorRequiredPropertyMissing
message: 'Required property is missing.'
```