### PR TITLE
Security: Placeholder Error Mapping in Request Builders

### DIFF
--- a/msgraph/generated/admin/service_announcement/messages/archive/archive_request_builder.py
+++ b/msgraph/generated/admin/service_announcement/messages/archive/archive_request_builder.py
@@ -47,7 +47,8 @@ class ArchiveRequestBuilder(BaseRequestBuilder):
         from .....models.o_data_errors.o_data_error import ODataError
 
         error_mapping: dict[str, type[ParsableFactory]] = {
-            "XXX": ODataError,
+            "4XX": ODataError,
+            "5XX": ODataError,
         }
         if not self.request_adapter:
             raise Exception("Http core is null") 


### PR DESCRIPTION
## Summary

Security: Placeholder Error Mapping in Request Builders

## Problem

**Severity**: `Medium` | **File**: `msgraph/generated/admin/service_announcement/messages/archive/archive_request_builder.py:L47`

All request builder classes use 'XXX' as a placeholder in error_mapping dictionaries: `error_mapping: dict[str, type[ParsableFactory]] = {'XXX': ODataError}`. This placeholder was not replaced during code generation and indicates incomplete error handling for HTTP status codes.

## Solution

Replace 'XXX' placeholder with actual HTTP status code mappings (e.g., '4XX', '5XX', or specific codes like '400', '401', '403', '404', '500') to properly handle API error responses.

## Changes

- `msgraph/generated/admin/service_announcement/messages/archive/archive_request_builder.py` (modified)