### PR TITLE
chore(main): Exclude kiota-dom-export.txt from builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ documentation = "https://github.com/microsoftgraph/msgraph-sdk-python/docs"
 [tool.flit.module]
 name = "msgraph"
 
+[tool.flit.sdist]
+exclude = ["msgraph/generated/kiota-dom-export.txt"]
+
 [tool.mypy]
 warn_unused_configs = true
 files = "msgraph"


### PR DESCRIPTION
kiota-dom-export.txt is not needed at runtime and is a very large file (~32MB), contributing to a bloated package.

Fixes #1287

@lramosvea Please review.  Note that I hadn't originally created this PR, because I was under the impression that this repository's content was auto-generated as I saw recent PRs from a bot updating these files.

I also wasn't sure if this was a chore or build or something else - let me know if you want it changed.