### PR TITLE
chore(deps-dev): consolidate dependabot dependency updates

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -70,7 +70,7 @@ tomlkit==0.14.0
 typing_extensions==4.15.0
 tzdata==2026.1
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 wrapt==1.17.3
 yapf==0.43.0
 yarl==1.22.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ httpcore==1.0.9
 httpx==0.28.1
 hyperframe==6.1.0
 idna==3.11
-importlib-metadata==8.5.0
+importlib-metadata==9.0.0
 isort==6.1.0
 lazy-object-proxy==1.12.0
 lexid==2021.1006

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ hpack==4.1.0
 httpcore==1.0.9
 httpx==0.28.1
 hyperframe==6.1.0
-idna==3.11
+idna==3.15
 importlib-metadata==8.5.0
 isort==6.1.0
 lazy-object-proxy==1.12.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,9 +46,9 @@ msgraph-core==1.3.8
 multidict==6.7.1
 mypy==1.19.1
 mypy-extensions==1.1.0
-opentelemetry-api==1.41.0
-opentelemetry-sdk==1.41.0
-opentelemetry-semantic-conventions==0.62b0
+opentelemetry-api==1.42.0
+opentelemetry-sdk==1.42.0
+opentelemetry-semantic-conventions==0.63b0
 packaging==26.1
 pathlib2==2.3.7.post1
 platformdirs==4.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -58,7 +58,7 @@ PyJWT==2.12.1
 pylint==3.3.9
 pyproject_hooks==1.2.0
 python-dateutil==2.9.0.post0
-requests==2.32.5
+requests==2.33.0
 six==1.17.0
 sniffio==1.3.1
 std-uritemplate>=2.0.0


### PR DESCRIPTION
This PR consolidates the following dependabot PRs into a single update:

- #1490 - bump urllib3 from 2.6.3 to 2.7.0
- #1489 - bump requests from 2.32.5 to 2.33.0
- #1487 - bump idna from 3.11 to 3.15
- #1486 - bump importlib-metadata from 8.5.0 to 9.0.0
- #1485 - bump the open-telemetry group (api 1.41.0→1.42.0, sdk 1.41.0→1.42.0, semantic-conventions 0.62b0→0.63b0)

All changes are in \equirements-dev.txt\ (dev dependencies only).

Supersedes: #1490, #1489, #1487, #1486, #1485