### PR TITLE
fix(main): URL-encode commas in image_with_width_with_height_with_fitting_mode() URL template

### DIFF
--- a/msgraph/generated/drives/item/items/item/workbook/worksheets/item/charts/item/image_with_width_with_height_with_fitting_mode/image_with_width_with_height_with_fitting_mode_request_builder.py
+++ b/msgraph/generated/drives/item/items/item/workbook/worksheets/item/charts/item/image_with_width_with_height_with_fitting_mode/image_with_width_with_height_with_fitting_mode_request_builder.py
@@ -35,7 +35,7 @@ class ImageWithWidthWithHeightWithFittingModeRequestBuilder(BaseRequestBuilder):
             path_parameters['fittingMode'] = fitting_mode
             path_parameters['height'] = height
             path_parameters['width'] = width
-        super().__init__(request_adapter, "{+baseurl}/drives/{drive%2Did}/items/{driveItem%2Did}/workbook/worksheets/{workbookWorksheet%2Did}/charts/{workbookChart%2Did}/image(width={width},height={height},fittingMode='{fittingMode}')", path_parameters)
+        super().__init__(request_adapter, "{+baseurl}/drives/{drive%2Did}/items/{driveItem%2Did}/workbook/worksheets/{workbookWorksheet%2Did}/charts/{workbookChart%2Did}/image(width={width}%2Cheight={height}%2CfittingMode='{fittingMode}')", path_parameters)
     
     async def get(self,request_configuration: Optional[RequestConfiguration[QueryParameters]] = None) -> Optional[ImageWithWidthWithHeightWithFittingModeGetResponse]:
         """


### PR DESCRIPTION
**issue Description**

The generated URL template for
image_with_width_with_height_with_fitting_mode() used literal commas
to separate the width, height, and fittingMode parameters in the template URL

  `image(width={width},height={height},fittingMode='{fittingMode}')`

Unencoded commas here caused the request to fail. The comas were getting omitted while making the actual request. Encoding them as
%2C resolves the issue:

  `image(width={width}%2Cheight={height}%2CfittingMode='{fittingMode}')`

